### PR TITLE
Add trigger, tests, and deploy script for Yearn Curve tBTC vault

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,7 @@
 - `CompoundExchangeRate`: Triggers if a Compound market's `exchangeRateStored` drops between consecutive blocks
 - `YearnSharePrice`: Triggers if a Yearn vault's `pricePerShare` drops between consecutive blocks
 - `YearnCrvTricrypto`: Triggers if the Yearn crvTricrypto vault's `pricePerShare` drops between consecutive blocks, or the Tricrypto pool fails
+- `YearnCrvTwoTokens`: Triggers when the Yearn vault `pricePerShare` falls by over 50%, the underlying Curve pool's virtual price falls by over 50%, or the internal balances tracked in the Curve pool are over 50% lower than the true balances
 
 ## Development and Deployment
 

--- a/contracts/YearnCrvTricrypto.sol
+++ b/contracts/YearnCrvTricrypto.sol
@@ -1,6 +1,6 @@
 pragma solidity ^0.8.5;
 
-import "./interfaces/ICrvTricrypto.sol";
+import "./interfaces/ICurvePool.sol";
 import "./interfaces/IERC20.sol";
 import "./interfaces/ITrigger.sol";
 import "./interfaces/IYVaultV2.sol";
@@ -50,7 +50,7 @@ contract YearnCrvTricrypto is ITrigger {
   IYVaultV2 public immutable vault;
 
   /// @notice Curve tricrypto pool used as a strategy by `vault`
-  ICrvTricrypto public immutable curve;
+  ICurvePool public immutable curve;
 
   /// @notice Last read pricePerShare
   uint256 public lastPricePerShare;
@@ -76,11 +76,11 @@ contract YearnCrvTricrypto is ITrigger {
   ) ITrigger(_name, _symbol, _description, _platformIds, _recipient) {
     // Set vault
     vault = IYVaultV2(_vault);
-    curve = ICrvTricrypto(_curve);
+    curve = ICurvePool(_curve);
 
     // Save current values (immutables can't be read at construction, so we don't use `vault` or `curve` directly)
     lastPricePerShare = IYVaultV2(_vault).pricePerShare();
-    lastVirtualPrice = ICrvTricrypto(_curve).get_virtual_price();
+    lastVirtualPrice = ICurvePool(_curve).get_virtual_price();
   }
 
   // --- Trigger condition ---

--- a/contracts/YearnCrvTwoTokens.sol
+++ b/contracts/YearnCrvTwoTokens.sol
@@ -1,6 +1,6 @@
 pragma solidity ^0.8.6;
 
-import "./interfaces/ICrvTricrypto.sol";
+import "./interfaces/ICurvePool.sol";
 import "./interfaces/IERC20.sol";
 import "./interfaces/ITrigger.sol";
 import "./interfaces/IYVaultV2.sol";
@@ -47,7 +47,7 @@ contract YearnCrvTwoTokens is ITrigger {
   IYVaultV2 public immutable vault;
 
   /// @notice Curve tricrypto pool used as a strategy by `vault`
-  ICrvTricrypto public immutable curve;
+  ICurvePool public immutable curve;
 
   /// @notice Last read pricePerShare
   uint256 public lastPricePerShare;
@@ -77,13 +77,13 @@ contract YearnCrvTwoTokens is ITrigger {
   ) ITrigger(_name, _symbol, _description, _platformIds, _recipient) {
     // Set trigger data
     vault = IYVaultV2(_vault);
-    curve = ICrvTricrypto(_curve);
+    curve = ICurvePool(_curve);
     token0 = _token0;
     token1 = _token1;
 
     // Save current values (immutables can't be read at construction, so we don't use `vault` or `curve` directly)
     lastPricePerShare = IYVaultV2(_vault).pricePerShare();
-    lastVirtualPrice = ICrvTricrypto(_curve).get_virtual_price();
+    lastVirtualPrice = ICurvePool(_curve).get_virtual_price();
   }
 
   // --- Trigger condition ---

--- a/contracts/YearnCrvTwoTokens.sol
+++ b/contracts/YearnCrvTwoTokens.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.8.5;
+pragma solidity ^0.8.6;
 
 import "./interfaces/ICrvTricrypto.sol";
 import "./interfaces/IERC20.sol";

--- a/contracts/YearnCrvTwoTokens.sol
+++ b/contracts/YearnCrvTwoTokens.sol
@@ -1,0 +1,121 @@
+pragma solidity ^0.8.5;
+
+import "./interfaces/ICrvTricrypto.sol";
+import "./interfaces/IERC20.sol";
+import "./interfaces/ITrigger.sol";
+import "./interfaces/IYVaultV2.sol";
+
+/**
+ * @notice Defines a trigger that is toggled if any of the following conditions occur:
+ *   1. The price per share for the V2 yVault significantly decreases between consecutive checks. Under normal
+ *      operation, this value should only increase. A decrease indicates something is wrong with the Yearn vault
+ *   2. Curve Tricrypto token balances are significantly lower than what the pool expects them to be
+ *   3. Curve Tricrypto virtual price drops significantly
+ * @dev This trigger is for Yearn V2 Vaults that use a Curve pool with two underlying tokens
+ */
+contract YearnCrvTwoTokens is ITrigger {
+  // --- Tokens ---
+  // Token addresses
+  IERC20 internal constant usdt = IERC20(0xdAC17F958D2ee523a2206206994597C13D831ec7);
+  IERC20 internal constant wbtc = IERC20(0x2260FAC5E5542a773Aa44fBCfeDf7C193bc2C599);
+  IERC20 internal constant weth = IERC20(0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2);
+
+  // Token indices in Curve pool arrays
+  uint256 internal constant usdtIndex = 0;
+  uint256 internal constant wbtcIndex = 1;
+  uint256 internal constant wethIndex = 2;
+
+  // --- Tolerances ---
+  /// @dev Scale used to define percentages. Percentages are defined as tolerance / scale
+  uint256 public constant scale = 1000;
+
+  /// @dev In Yearn V2 vaults, the pricePerShare decreases immediately after a harvest, and typically ramps up over the
+  /// next six hours. Therefore we cannot simply check that the pricePerShare increases. Instead, we consider the vault
+  /// triggered if the pricePerShare drops by more than 50% from it's previous value. This is conservative, but
+  /// previous Yearn bugs resulted in pricePerShare drops of 0.5% – 10%, and were only temporary drops with users able
+  /// to be made whole. Therefore this trigger requires a large 50% drop to minimize false positives. The tolerance
+  /// is defined such that we trigger if: currentPricePerShare < lastPricePerShare * tolerance / 1000. This means
+  /// if you want to trigger after a 20% drop, you should set the tolerance to 1000 - 200 = 800
+  uint256 public constant vaultTol = scale - 500; // 50% drop, represented on a scale where 1000 = 100%
+
+  /// @dev Consider trigger toggled if Curve virtual price drops by this percentage. Similar to the Yearn V2 price
+  /// per share, the virtual price is expected to decrease during normal operation, but it can never decrease by
+  /// more than 50% during normal operation. Therefore we check for a 51% drop
+  uint256 public constant virtualPriceTol = scale - 510; // 51% drop, since 1000-510=490, and multiplying by 0.49 = 51% drop
+
+  /// @dev Consider trigger toggled if Curve internal balances are lower than true balances by this percentage
+  uint256 public constant balanceTol = scale - 500; // 50% drop
+
+  // --- Trigger Data ---
+  /// @notice Yearn vault this trigger is for
+  IYVaultV2 public immutable vault;
+
+  /// @notice Curve tricrypto pool used as a strategy by `vault`
+  ICrvTricrypto public immutable curve;
+
+  /// @notice Last read pricePerShare
+  uint256 public lastPricePerShare;
+
+  /// @notice Last read curve virtual price
+  uint256 public lastVirtualPrice;
+
+  // --- Constructor ---
+
+  /**
+   * @param _vault Address of the Yearn V2 vault this trigger should protect
+   * @param _curve Address of the Curve Tricrypto pool uses by the above Yearn vault
+   * @dev For definitions of other constructor parameters, see ITrigger.sol
+   */
+  constructor(
+    string memory _name,
+    string memory _symbol,
+    string memory _description,
+    uint256[] memory _platformIds,
+    address _recipient,
+    address _vault,
+    address _curve
+  ) ITrigger(_name, _symbol, _description, _platformIds, _recipient) {
+    // Set vault
+    vault = IYVaultV2(_vault);
+    curve = ICrvTricrypto(_curve);
+
+    // Save current values (immutables can't be read at construction, so we don't use `vault` or `curve` directly)
+    lastPricePerShare = IYVaultV2(_vault).pricePerShare();
+    lastVirtualPrice = ICrvTricrypto(_curve).get_virtual_price();
+  }
+
+  // --- Trigger condition ---
+
+  /**
+   * @dev Checks the yVault pricePerShare
+   */
+  function checkTriggerCondition() internal override returns (bool) {
+    // Read this blocks share price and virtual price
+    uint256 _currentPricePerShare = vault.pricePerShare();
+    uint256 _currentVirtualPrice = curve.get_virtual_price();
+
+    // Check trigger conditions. We could check one at a time and return as soon as one is true, but it is convenient
+    // to have the data that caused the trigger saved into the state, so we don't do that
+    bool _statusVault = _currentPricePerShare < ((lastPricePerShare * vaultTol) / scale);
+    bool _statusVirtualPrice = _currentVirtualPrice < ((lastVirtualPrice * virtualPriceTol) / scale);
+    bool _statusBalances = checkCurveBalances();
+
+    // Save the new data
+    lastPricePerShare = _currentPricePerShare;
+    lastVirtualPrice = _currentVirtualPrice;
+
+    // Return status
+    return _statusVault || _statusVirtualPrice || _statusBalances;
+  }
+
+  /**
+   * @dev Checks if the Curve internal balances are significantly lower than the true balances
+   * @return True if balances are out of tolerance and trigger should be toggled
+   */
+  function checkCurveBalances() internal view returns (bool) {
+    return
+      (usdt.balanceOf(address(curve)) < ((curve.balances(usdtIndex) * virtualPriceTol) / scale)) ||
+      (wbtc.balanceOf(address(curve)) < ((curve.balances(wbtcIndex) * virtualPriceTol) / scale)) ||
+      (weth.balanceOf(address(curve)) < ((curve.balances(wethIndex) * virtualPriceTol) / scale));
+  }
+}

--- a/contracts/interfaces/ICurvePool.sol
+++ b/contracts/interfaces/ICurvePool.sol
@@ -1,6 +1,6 @@
 pragma solidity ^0.8.5;
 
-interface ICrvTricrypto {
+interface ICurvePool {
   /// @notice Computes current virtual price
   function get_virtual_price() external view returns (uint256);
 
@@ -18,4 +18,7 @@ interface ICrvTricrypto {
 
   /// @notice Pool admin fee
   function balances(uint256 index) external view returns (uint256);
+
+  /// @notice Returns the address of the token for the provided index
+  function coins(uint256 index) external view returns (address);
 }

--- a/contracts/interfaces/IInterestRateModel.sol
+++ b/contracts/interfaces/IInterestRateModel.sol
@@ -1,4 +1,4 @@
-pragma solidity 0.8.5;
+pragma solidity ^0.8.5;
 
 /**
  * @notice Abstract contract for interest rate models

--- a/contracts/test/MockCrvTricrypto.sol
+++ b/contracts/test/MockCrvTricrypto.sol
@@ -1,11 +1,11 @@
 pragma solidity ^0.8.5;
 
-import "../interfaces/ICrvTricrypto.sol";
+import "../interfaces/ICurvePool.sol";
 
 /**
  * @notice Mock Curve Tricrypto pool, containing the same interface but configurable parameters for testing
  */
-contract MockCrvTricrypto is ICrvTricrypto {
+contract MockCrvTricrypto is ICurvePool {
   uint256 public override get_virtual_price;
   uint256 public override virtual_price;
   uint256 public override xcp_profit;

--- a/contracts/test/MockCrvTricrypto.sol
+++ b/contracts/test/MockCrvTricrypto.sol
@@ -33,4 +33,10 @@ contract MockCrvTricrypto is ICurvePool {
     require(index == 0 || index == 1 || index == 2, "bad index");
     return 1;
   }
+
+  function coins(uint256 index) external pure override returns (address) {
+    // This method is not used and is just to satisfy the interface this contract inherits from
+    index; // silence compiler warning about unused variables
+    return address(0);
+  }
 }

--- a/hardhat.config.ts
+++ b/hardhat.config.ts
@@ -66,7 +66,7 @@ const config: HardhatUserConfig = {
     compilers: [
       {
         // Used for triggers
-        version: '0.8.5',
+        version: '0.8.6',
         settings: { metadata: { bytecodeHash: 'none' }, optimizer: { enabled: true, runs: 999999 } },
       },
       {

--- a/scripts/create-protection-market-yCrvTBTC.ts
+++ b/scripts/create-protection-market-yCrvTBTC.ts
@@ -58,9 +58,9 @@ async function main(): Promise<void> {
   //   - Linear increase from 3% to 9% borrow rate at 80% utilization
   //   - Linear increase from 9% to 85% borrow rate at 100% utilization
   const constructorArgs = [
-    '30000000000000000', // baseRatePerYear of 3% = 3e16
-    '120000000000000000', // multiplierPerYear of 12% = 1.2e17 gives 15% borrow rate at kink
-    '3500000000000000000', // jumpMultiplierPerYear of 3.5% = 3.5e18 gives 85% borrow rate at 100% utilization
+    '20000000000000000', // baseRatePerYear of 2% = 2e16
+    '160000000000000000', // multiplierPerYear of 16% = 1.6e17 gives 18% borrow rate at kink
+    '5000000000000000000', // jumpMultiplierPerYear of 500% = 5e18 gives 118% borrow rate at 100% utilization
     '800000000000000000', // kink of 0.8 = 8e17 = sets the model kink at 80% utilization
     '0x1725d89c5cf12F1E9423Dc21FdadC81C491a868b', // Cozy multisig
   ];

--- a/scripts/create-protection-market-yCrvTBTC.ts
+++ b/scripts/create-protection-market-yCrvTBTC.ts
@@ -1,0 +1,135 @@
+/**
+ * @notice Deploys the `YearnCrvTwoTokens` trigger and creates a protection market
+ */
+
+import hre from 'hardhat';
+import '@nomiclabs/hardhat-ethers';
+import { Contract, ContractFactory, utils } from 'ethers';
+import chalk from 'chalk';
+import { getChainId, getContractAddress, getGasPrice, logSuccess, logFailure, findLog, waitForInput, fundAccount } from '../utils/utils'; // prettier-ignore
+import comptrollerAbi from '../abi/Comptroller.json';
+
+// STEP 0: ENVIRONMENT SETUP
+const provider = hre.ethers.provider;
+const signer = new hre.ethers.Wallet(process.env.PRIVATE_KEY as string, hre.ethers.provider);
+const chainId = getChainId(hre);
+const { AddressZero } = hre.ethers.constants;
+
+// STEP 1: TRIGGER CONTRACT SETUP
+const name = 'Yearn V2 Curve TBTC Trigger'; // name
+const symbol = 'yCrvTBTC-TRIG'; // symbol
+const description = "Triggers when the Yearn vault share price falls by over 50%, the Curve tBTC pool's virtual price falls by over 50%, or the internal balances tracked in the Curve tBTC pool are over 50% lower than the true balances"; // prettier-ignore
+const platformIds = [1, 3]; // platform IDs for Yearn and Curve, respectively
+const recipient = '0xSetRecipientAddressHere'; // subsidy recipient
+const yearnVaultAddress = '0x23D3D0f1c697247d5e0a9efB37d8b0ED0C464f7f'; // mainnet Yearn v2 vault
+const curvePoolAddress = '0xC25099792E9349C7DD09759744ea681C7de2cb66'; // mainnet Curve pool
+const token0 = '0x8dAEBADE922dF735c38C80C7eBD708Af50815fAa'; // tBTC
+const token1 = '0x075b1bb99792c9E1041bA13afEf80C91a1e70fB3'; // crvRenWSBTC
+
+// STEP 2: TRIGGER CONTRACT DEVELOPMENT
+// For this step, see the ITrigger.sol and MockTrigger.sol examples and the corresponding documentation
+
+// STEP 3: PROTECTION MARKET DEPLOYMENT
+async function main(): Promise<void> {
+  if (!utils.isAddress(recipient)) throw new Error('\n\n**** Please set the recipient address on line 23 ****\n');
+
+  // Compile contracts to make sure we're using the latest version of the trigger contracts
+  await fundAccount('0xEeeeeEeeeEeEeeEeEeEeeEEEeeeeEeeeeeeeEEeE', '5', signer.address, hre);
+  await hre.run('compile');
+
+  // VERIFICATION
+  // Verify the user is ok with the provided inputs
+  console.log(chalk.bold.yellow('\nPLEASE VERIFY THE BELOW PARAMETERS\n'));
+  console.log('  Deploying protection market for:   Yearn Curve TBTC');
+  console.log(`  Deployer address:                  ${signer.address}`);
+  console.log(`  Deploying to network:              ${hre.network.name}`);
+
+  const response = await waitForInput('\nDo you want to continue with deployment? y/N\n');
+  if (response !== 'y') {
+    logFailure('\nUser chose to cancel deployment. Exiting script');
+    return;
+  }
+  logSuccess('Continuing with deployment...\n');
+
+  // DEPLOY INTEREST RATE MODEL
+  // Get instance of the Trigger ContractFactory with our signer attached
+  const irModelFactory: ContractFactory = await hre.ethers.getContractFactory('JumpRateModelV2', signer);
+
+  // Deploy the interest rate model, configured with the following parameters:
+  //   - 3% base borrow rate at zero utilization
+  //   - Linear increase from 3% to 9% borrow rate at 80% utilization
+  //   - Linear increase from 9% to 85% borrow rate at 100% utilization
+  const constructorArgs = [
+    '30000000000000000', // baseRatePerYear of 3% = 3e16
+    '120000000000000000', // multiplierPerYear of 12% = 1.2e17 gives 15% borrow rate at kink
+    '3500000000000000000', // jumpMultiplierPerYear of 3.5% = 3.5e18 gives 85% borrow rate at 100% utilization
+    '800000000000000000', // kink of 0.8 = 8e17 = sets the model kink at 80% utilization
+    '0x1725d89c5cf12F1E9423Dc21FdadC81C491a868b', // Cozy multisig
+  ];
+  const irModel: Contract = await irModelFactory.deploy(...constructorArgs);
+  await irModel.deployed();
+  logSuccess(`Interest rate model deployed to ${irModel.address}`);
+
+  // DEPLOY TRIGGER
+  // Get instance of the Trigger ContractFactory with our signer attached
+  const triggerFactory: ContractFactory = await hre.ethers.getContractFactory('YearnCrvTwoTokens', signer);
+
+  // Deploy the trigger contract (last constructor parameter is specific to the mock trigger contract)
+  const triggerParams = [
+    name,
+    symbol,
+    description,
+    platformIds,
+    recipient,
+    yearnVaultAddress,
+    curvePoolAddress,
+    token0,
+    token1,
+  ];
+  const trigger: Contract = await triggerFactory.deploy(...triggerParams);
+  await trigger.deployed();
+  logSuccess(`YearnCrvTwoTokens trigger deployed to ${trigger.address}`);
+
+  // VERIFY UNDERLYING
+  // Let's choose WBTC as the underlying, so first we need to check if there's a WBTC Money Market.
+  // We know that Money Markets have a trigger address of the zero address, so we use that to query the Comptroller
+  // for the Money Market address
+  const wbtcAddress = getContractAddress('WBTC', chainId);
+  const comptrollerAddress = getContractAddress('Comptroller', chainId);
+  const comptroller = new Contract(comptrollerAddress, comptrollerAbi, signer); // connect signer for sending transactions
+  const cozyEthAddress = await comptroller.getCToken(wbtcAddress, AddressZero);
+
+  // If the returned address is the zero address, a money market does not exist and we cannot deploy a protection
+  // market with WBTC as the underlying
+  if (cozyEthAddress === AddressZero) {
+    logFailure('No WBTC Money Market exists. Exiting script');
+    return;
+  }
+  logSuccess(`Safe to continue: Found WBTC Money Market at ${cozyEthAddress}`);
+
+  // DEPLOY PROTECTION MARKET
+  // If we're here, a WBTC Money Market exists, so it's safe to create our new Protection Market
+  const overrides = { gasPrice: await getGasPrice() };
+  const tx = await comptroller['deployProtectionMarket(address,address,address)'](
+    wbtcAddress,
+    trigger.address,
+    irModel.address,
+    overrides
+  );
+  console.log(`Creating Protection Market in transaction ${tx.hash}`);
+
+  // This should emit a ProtectionMarketListed event on success, so let's check for that event. If not found, this
+  // method will throw and print the Failure error codes which can be looked up in ErrorReporter.sol
+  const { log, receipt } = await findLog(tx, comptroller, 'ProtectionMarketListed', provider);
+  logSuccess(`Success! Protection Market deployed to ${log?.args.cToken}`);
+
+  // Done! You have successfully deployed your protection market
+}
+
+// We recommend this pattern to be able to use async/await everywhere and properly handle errors.
+main()
+  .then(() => process.exit(0))
+  .catch((error: Error) => {
+    console.error(error);
+    process.exit(1);
+  });

--- a/scripts/create-protection-market-yCrvTBTC.ts
+++ b/scripts/create-protection-market-yCrvTBTC.ts
@@ -18,7 +18,7 @@ const { AddressZero } = hre.ethers.constants;
 // STEP 1: TRIGGER CONTRACT SETUP
 const name = 'Yearn V2 Curve TBTC Trigger'; // name
 const symbol = 'yCrvTBTC-TRIG'; // symbol
-const description = "Triggers when the Yearn vault share price falls by over 50%, the Curve tBTC pool's virtual price falls by over 50%, or the internal balances tracked in the Curve tBTC pool are over 50% lower than the true balances"; // prettier-ignore
+const description = "Triggers when the Yearn vault share price decreases by more than 50% between consecutive checks, the Curve tBTC pool's virtual price decreases by more than 50% between consecutive checks, or the internal balances tracked in the Curve tBTC pool are more than 50% lower than the true balances"; // prettier-ignore
 const platformIds = [1, 3]; // platform IDs for Yearn and Curve, respectively
 const recipient = '0xSetRecipientAddressHere'; // subsidy recipient
 const yearnVaultAddress = '0x23D3D0f1c697247d5e0a9efB37d8b0ED0C464f7f'; // mainnet Yearn v2 vault

--- a/scripts/create-protection-market-yCrvTBTC.ts
+++ b/scripts/create-protection-market-yCrvTBTC.ts
@@ -23,8 +23,6 @@ const platformIds = [1, 3]; // platform IDs for Yearn and Curve, respectively
 const recipient = '0xSetRecipientAddressHere'; // subsidy recipient
 const yearnVaultAddress = '0x23D3D0f1c697247d5e0a9efB37d8b0ED0C464f7f'; // mainnet Yearn v2 vault
 const curvePoolAddress = '0xC25099792E9349C7DD09759744ea681C7de2cb66'; // mainnet Curve pool
-const token0 = '0x8dAEBADE922dF735c38C80C7eBD708Af50815fAa'; // tBTC
-const token1 = '0x075b1bb99792c9E1041bA13afEf80C91a1e70fB3'; // crvRenWSBTC
 
 // STEP 2: TRIGGER CONTRACT DEVELOPMENT
 // For this step, see the ITrigger.sol and MockTrigger.sol examples and the corresponding documentation
@@ -75,17 +73,7 @@ async function main(): Promise<void> {
   const triggerFactory: ContractFactory = await hre.ethers.getContractFactory('YearnCrvTwoTokens', signer);
 
   // Deploy the trigger contract (last constructor parameter is specific to the mock trigger contract)
-  const triggerParams = [
-    name,
-    symbol,
-    description,
-    platformIds,
-    recipient,
-    yearnVaultAddress,
-    curvePoolAddress,
-    token0,
-    token1,
-  ];
+  const triggerParams = [name, symbol, description, platformIds, recipient, yearnVaultAddress, curvePoolAddress];
   const trigger: Contract = await triggerFactory.deploy(...triggerParams);
   await trigger.deployed();
   logSuccess(`YearnCrvTwoTokens trigger deployed to ${trigger.address}`);

--- a/scripts/create-protection-market-yCrvTricrypto.ts
+++ b/scripts/create-protection-market-yCrvTricrypto.ts
@@ -59,7 +59,7 @@ async function main(): Promise<void> {
   const constructorArgs = [
     '30000000000000000', // baseRatePerYear of 3% = 3e16
     '120000000000000000', // multiplierPerYear of 12% = 1.2e17 gives 15% borrow rate at kink
-    '3500000000000000000', // jumpMultiplierPerYear of 3.5% = 3.5e18 gives 85% borrow rate at 100% utilization
+    '3500000000000000000', // jumpMultiplierPerYear of 350% = 3.5e18 gives 85% borrow rate at 100% utilization
     '800000000000000000', // kink of 0.8 = 8e17 = sets the model kink at 80% utilization
     '0x1725d89c5cf12F1E9423Dc21FdadC81C491a868b', // Cozy multisig
   ];

--- a/scripts/create-protection-market-yCrvTricrypto.ts
+++ b/scripts/create-protection-market-yCrvTricrypto.ts
@@ -4,7 +4,7 @@
 
 import hre from 'hardhat';
 import '@nomiclabs/hardhat-ethers';
-import { Contract, ContractFactory } from 'ethers';
+import { Contract, ContractFactory, utils } from 'ethers';
 import chalk from 'chalk';
 import { getChainId, getContractAddress, getGasPrice, logSuccess, logFailure, findLog, waitForInput } from '../utils/utils'; // prettier-ignore
 import comptrollerAbi from '../abi/Comptroller.json';
@@ -20,7 +20,7 @@ const name = 'Yearn Curve Tricrypto Trigger'; // name
 const symbol = 'yCRV-TRICRYPTO-TRIG'; // symbol
 const description = 'Triggers when the Yearn vault share price falls by over 50%, the Tricrypto pool virtual price falls by over 50%, or the internal balances tracked in the Tricrypto pool are over 50% lower than the true balances'; // prettier-ignore
 const platformIds = [1, 3]; // platform IDs for Yearn and Curve, respectively
-const recipient = '0x1234567890AbcdEF1234567890aBcdef12345678'; // subsidy recipient
+const recipient = '0xSetRecipientAddressHere'; // subsidy recipient
 const yearnVaultAddress = '0x3D980E50508CFd41a13837A60149927a11c03731'; // mainnet Yearn crvTricrypto vault
 const curveTricryptoAddress = '0xD51a44d3FaE010294C616388b506AcdA1bfAAE46'; // mainnet Curve Tricrypto pool
 
@@ -29,6 +29,8 @@ const curveTricryptoAddress = '0xD51a44d3FaE010294C616388b506AcdA1bfAAE46'; // m
 
 // STEP 3: PROTECTION MARKET DEPLOYMENT
 async function main(): Promise<void> {
+  if (!utils.isAddress(recipient)) throw new Error('\n\n**** Please set the recipient address on line 23 ****\n');
+
   // Compile contracts to make sure we're using the latest version of the trigger contracts
   await hre.run('compile');
 

--- a/test/YearnCrvTricrypto.test.ts
+++ b/test/YearnCrvTricrypto.test.ts
@@ -4,7 +4,7 @@ import { expect } from 'chai';
 import type { BigNumberish } from '@ethersproject/bignumber';
 import { keccak256 } from '@ethersproject/keccak256';
 import { SignerWithAddress } from '@nomiclabs/hardhat-ethers/dist/src/signer-with-address';
-import { MockCozyToken, IYVaultV2, ICrvTricrypto, YearnCrvTricrypto, IERC20 } from '../typechain';
+import { MockCozyToken, IYVaultV2, ICurvePool, YearnCrvTricrypto, IERC20 } from '../typechain';
 
 // --- Constants and extracted methods ---
 const { deployContract, loadFixture } = waffle;
@@ -47,7 +47,7 @@ async function balanceOf(token: keyof typeof tokenBalanceOfSlots, address: strin
 describe('YearnCrvTricrypto', function () {
   // --- Data ---
   let yCrvTricrypto: IYVaultV2;
-  let crvTricrypto: ICrvTricrypto;
+  let crvTricrypto: ICurvePool;
   let crvToken: IERC20;
   let deployer: SignerWithAddress;
   let trigger: YearnCrvTricrypto;
@@ -109,7 +109,7 @@ describe('YearnCrvTricrypto', function () {
 
     // Get mainnet contract instances
     const yCrvTricrypto = <IYVaultV2>await ethers.getContractAt('IYVaultV2', yearnVaultAddress);
-    const crvTricrypto = <ICrvTricrypto>await ethers.getContractAt('ICrvTricrypto', curveTricryptoAddress);
+    const crvTricrypto = <ICurvePool>await ethers.getContractAt('ICurvePool', curveTricryptoAddress);
     const crvToken = <IERC20>await ethers.getContractAt('IERC20', curveTokenAddress);
 
     // Deploy YearnCrvTricrypto trigger

--- a/test/YearnCrvTwoTokens.test.ts
+++ b/test/YearnCrvTwoTokens.test.ts
@@ -149,8 +149,6 @@ vaults.forEach((vault) => {
         recipient.address, // subsidy recipient
         vault.yearnVault, // mainnet Yearn crvTricrypto vault
         vault.curvePool, // mainnet Curve Tricrypto pool
-        tokenAddresses[vault.curvePoolTokens[0]],
-        tokenAddresses[vault.curvePoolTokens[1]],
       ];
 
       const YearnCrvTwoTokensArtifact = await artifacts.readArtifact('YearnCrvTwoTokens');

--- a/test/YearnCrvTwoTokens.test.ts
+++ b/test/YearnCrvTwoTokens.test.ts
@@ -4,7 +4,7 @@ import { expect } from 'chai';
 import type { BigNumberish } from '@ethersproject/bignumber';
 import { keccak256 } from '@ethersproject/keccak256';
 import { SignerWithAddress } from '@nomiclabs/hardhat-ethers/dist/src/signer-with-address';
-import { MockCozyToken, IYVaultV2, ICrvTricrypto, YearnCrvTwoTokens, IERC20 } from '../typechain';
+import { MockCozyToken, IYVaultV2, ICurvePool, YearnCrvTwoTokens, IERC20 } from '../typechain';
 
 // --- Constants and extracted methods ---
 const { deployContract, loadFixture } = waffle;
@@ -76,7 +76,7 @@ vaults.forEach((vault) => {
   describe(`Yearn Vault: ${vault.name}`, function () {
     // --- Data ---
     let yCrvTricrypto: IYVaultV2;
-    let crvTricrypto: ICrvTricrypto;
+    let crvTricrypto: ICurvePool;
     let crvToken: IERC20;
     let deployer: SignerWithAddress;
     let trigger: YearnCrvTwoTokens;
@@ -137,7 +137,7 @@ vaults.forEach((vault) => {
 
       // Get mainnet contract instances
       const yCrvTricrypto = <IYVaultV2>await ethers.getContractAt('IYVaultV2', vault.yearnVault);
-      const crvTricrypto = <ICrvTricrypto>await ethers.getContractAt('ICrvTricrypto', vault.curvePool);
+      const crvTricrypto = <ICurvePool>await ethers.getContractAt('ICurvePool', vault.curvePool);
       const crvToken = <IERC20>await ethers.getContractAt('IERC20', vault.curveToken);
 
       // Deploy YearnCrvTwoTokens trigger

--- a/test/YearnCrvTwoTokens.test.ts
+++ b/test/YearnCrvTwoTokens.test.ts
@@ -1,0 +1,314 @@
+// --- Imports ---
+import { artifacts, ethers, network, waffle } from 'hardhat';
+import { expect } from 'chai';
+import type { BigNumberish } from '@ethersproject/bignumber';
+import { keccak256 } from '@ethersproject/keccak256';
+import { SignerWithAddress } from '@nomiclabs/hardhat-ethers/dist/src/signer-with-address';
+import { MockCozyToken, IYVaultV2, ICrvTricrypto, YearnCrvTwoTokens, IERC20 } from '../typechain';
+
+// --- Constants and extracted methods ---
+const { deployContract, loadFixture } = waffle;
+const { MaxUint256: MAX_UINT } = ethers.constants;
+const { defaultAbiCoder, hexZeroPad, hexStripZeros } = ethers.utils;
+const BN = (x: BigNumberish) => ethers.BigNumber.from(x);
+const to32ByteHex = (x: BigNumberish) => hexZeroPad(BN(x).toHexString(), 32);
+
+// Mainnet token addresses
+const tokenAddresses = {
+  usdt: '0xdAC17F958D2ee523a2206206994597C13D831ec7',
+  wbtc: '0x2260FAC5E5542a773Aa44fBCfeDf7C193bc2C599',
+  weth: '0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2',
+};
+
+type CurveUnderlying = keyof typeof tokenAddresses;
+
+interface VaultInfo {
+  name: string;
+  yearnVault: string;
+  curvePool: string;
+  curveToken: string;
+  curvePoolTokens: CurveUnderlying[];
+}
+
+// Yearn Vault / Curve Pool pairings to test
+const vaults: VaultInfo[] = [
+  {
+    name: 'crvTricrypto',
+    yearnVault: '0x3D980E50508CFd41a13837A60149927a11c03731',
+    curvePool: '0xD51a44d3FaE010294C616388b506AcdA1bfAAE46',
+    curveToken: '0xc4AD29ba4B3c580e6D59105FFf484999997675Ff',
+    curvePoolTokens: ['usdt', 'wbtc', 'weth'],
+  },
+];
+
+// const vault.yearnVault = '0x3D980E50508CFd41a13837A60149927a11c03731'; // mainnet Yearn crvTricrypto vault
+// const vault.curvePool = '0xD51a44d3FaE010294C616388b506AcdA1bfAAE46'; // mainnet Curve Tricrypto pool
+// const vault.curveToken = '0xc4AD29ba4B3c580e6D59105FFf484999997675Ff'; // Curve Tricrypto pool token
+
+// Define the balanceOf mapping slot number to use for finding the slot used to store balance of a given address
+const tokenBalanceOfSlots = { usdt: '0x2', wbtc: '0x0', weth: '0x3' };
+
+// --- Helper methods ---
+// Returns the storage slot for a mapping from an `address` to a value, given the slot of the mapping itself, `mappingSlot`
+// Read more at https://docs.soliditylang.org/en/latest/internals/layout_in_storage.html#mappings-and-dynamic-arrays
+const getStorageSlot = (mappingSlot: string, address: string) => {
+  // `defaultAbiCoder.encode` is equivalent to Solidity's `abi.encode()`, and we strip leading zeros from the hashed
+  // value to conform to the JSON-RPC spec: https://ethereum.org/en/developers/docs/apis/json-rpc/#hex-value-encoding
+  return hexStripZeros(keccak256(defaultAbiCoder.encode(['address', 'uint256'], [address, mappingSlot])));
+};
+
+// Gets token balance
+async function balanceOf(token: CurveUnderlying, address: string) {
+  const tokenAddress = tokenAddresses[token];
+  if (!tokenAddress) throw new Error('Invalid token selection');
+  const abi = ['function balanceOf(address) external view returns (uint256)'];
+  const contract = new ethers.Contract(tokenAddress, abi, ethers.provider);
+  return (await contract.balanceOf(address)).toBigInt();
+}
+
+vaults.forEach((vault) => {
+  describe.only(`Yearn Vault: ${vault.name}`, function () {
+    // --- Data ---
+    let yCrvTricrypto: IYVaultV2;
+    let crvTricrypto: ICrvTricrypto;
+    let crvToken: IERC20;
+    let deployer: SignerWithAddress;
+    let trigger: YearnCrvTwoTokens;
+    let triggerParams: (string | number[])[] = []; // trigger params deployment parameters
+
+    // --- Functions modifying storage ---
+    /**
+     * @notice Change Yearn vault's price per share by modifying total supply (since share price is a getter method that
+     * divides by total token supply)
+     * @param supply New total supply. To zero out share price, use MAX_UINT256, which simulates unlimited minting of
+     * shares, making price per share effectively 0
+     */
+    async function setYearnTotalSupply(supply: BigNumberish) {
+      const storageSlot = '0x5'; // storage slot 5 in Yearn vault contains total supply
+      await network.provider.send('hardhat_setStorageAt', [vault.yearnVault, storageSlot, to32ByteHex(supply)]);
+    }
+
+    /**
+     * @notice Change Curve pool's virtual price by modifying total supply (since virtual price is a getter method that
+     * divides by total token supply)
+     * @param supply New total supply. To zero out share price, use MAX_UINT256, which simulates unlimited minting of
+     * shares, making price per share effectively 0
+     */
+    async function setCrvTotalSupply(supply: BigNumberish) {
+      const storageSlot = '0x4'; // storage slot 4 is Curve token total supply
+      await network.provider.send('hardhat_setStorageAt', [vault.curveToken, storageSlot, to32ByteHex(supply)]);
+    }
+
+    /**
+     * @notice Modify the balance of a token in the Curve pool
+     * @param token Token symbol
+     * @param balance New balance to set
+     */
+    async function modifyCrvBalance(token: CurveUnderlying, numerator: bigint, denominator: bigint) {
+      const value = ((await balanceOf(token, vault.curvePool)) * numerator) / denominator;
+      const tokenAddress = tokenAddresses[token];
+      if (!tokenAddress) throw new Error('Invalid token selection');
+      const mappingSlot = tokenBalanceOfSlots[token];
+      const storageSlot = getStorageSlot(mappingSlot, vault.curvePool);
+      await network.provider.send('hardhat_setStorageAt', [tokenAddress, storageSlot, to32ByteHex(value)]);
+    }
+
+    // --- Test fixture ---
+
+    // Executes checkAndToggleTrigger and verifies the expected state
+    async function assertTriggerStatus(status: boolean) {
+      await trigger.checkAndToggleTrigger();
+      expect(await trigger.isTriggered()).to.equal(status);
+    }
+
+    /**
+     * @dev We change the values in storage slots of mainnet contracts in our tests, and normally these would persist
+     * between tests. But we don't want that, so we use this fixture to automatically snapshot the state after loading
+     * the fixture and revert to it before each test: https://github.com/EthWorks/Waffle/blob/3f46a6c8093cb9edb1a68c3ba15c4b4499ad595d/waffle-provider/src/fixtures.ts#L13-L35
+     */
+    async function setupFixture() {
+      // Get user accounts
+      const [deployer, recipient] = await ethers.getSigners();
+
+      // Get mainnet contract instances
+      const yCrvTricrypto = <IYVaultV2>await ethers.getContractAt('IYVaultV2', vault.yearnVault);
+      const crvTricrypto = <ICrvTricrypto>await ethers.getContractAt('ICrvTricrypto', vault.curvePool);
+      const crvToken = <IERC20>await ethers.getContractAt('IERC20', vault.curveToken);
+
+      // Deploy YearnCrvTwoTokens trigger
+      const triggerParams = [
+        'Yearn Curve Tricrypto Trigger', // name
+        'yCRV-TRICRYPTO-TRIG', // symbol
+        'Triggers when the Yearn vault share price decreases, or the tricrypto pool fails', // description
+        [1, 3], // platform IDs for Yearn and Curve, respectively
+        recipient.address, // subsidy recipient
+        vault.yearnVault, // mainnet Yearn crvTricrypto vault
+        vault.curvePool, // mainnet Curve Tricrypto pool
+      ];
+
+      const YearnCrvTwoTokensArtifact = await artifacts.readArtifact('YearnCrvTwoTokens');
+      const trigger = <YearnCrvTwoTokens>await deployContract(deployer, YearnCrvTwoTokensArtifact, triggerParams);
+
+      return { deployer, yCrvTricrypto, crvTricrypto, crvToken, trigger, triggerParams };
+    }
+
+    // --- Tests ---
+    beforeEach(async () => {
+      ({ deployer, yCrvTricrypto, crvTricrypto, crvToken, trigger, triggerParams } = await loadFixture(setupFixture));
+    });
+
+    describe('Deployment', () => {
+      it('initializes properly', async () => {
+        expect(await trigger.name()).to.equal(triggerParams[0]);
+        expect(await trigger.symbol()).to.equal(triggerParams[1]);
+        expect(await trigger.description()).to.equal(triggerParams[2]);
+        const platformIds = (await trigger.getPlatformIds()).map((id) => id.toNumber());
+        expect(platformIds).to.deep.equal(triggerParams[3]); // use `.deep.equal` to compare array equality
+        expect(await trigger.recipient()).to.equal(triggerParams[4]);
+        expect(await trigger.vault()).to.equal(triggerParams[5]);
+        expect(await trigger.curve()).to.equal(triggerParams[6]);
+        expect(await trigger.vaultTol()).to.equal('500');
+        expect(await trigger.virtualPriceTol()).to.equal('490');
+      });
+    });
+
+    describe('checkAndToggleTrigger', () => {
+      it('does nothing when called on a valid market', async () => {
+        expect(await trigger.isTriggered()).to.be.false;
+        await trigger.checkAndToggleTrigger();
+        expect(await trigger.isTriggered()).to.be.false;
+      });
+
+      it('toggles trigger when called on a broken market', async () => {
+        expect(await trigger.isTriggered()).to.be.false;
+
+        await setYearnTotalSupply(MAX_UINT);
+        expect(await trigger.isTriggered()).to.be.false; // trigger not updated yet, so still expect false
+
+        const tx = await trigger.checkAndToggleTrigger();
+        await expect(tx).to.emit(trigger, 'TriggerActivated');
+        expect(await trigger.isTriggered()).to.be.true;
+      });
+
+      it('returns a boolean with the value of isTriggered', async () => {
+        // Deploy our helper contract for testing, which has a state variable called isTriggered that stores the last
+        // value returned from trigger.checkAndToggleTrigger()
+        const mockCozyTokenArtifact = await artifacts.readArtifact('MockCozyToken');
+        const mockCozyToken = <MockCozyToken>await deployContract(deployer, mockCozyTokenArtifact, [trigger.address]);
+        expect(await mockCozyToken.isTriggered()).to.be.false;
+
+        // Break the yVault
+        await setYearnTotalSupply(MAX_UINT);
+        await mockCozyToken.checkAndToggleTrigger();
+        expect(await mockCozyToken.isTriggered()).to.be.true;
+      });
+
+      it('properly updates the saved state', async () => {
+        // Update values
+        await setYearnTotalSupply(10n ** 18n); // don't set them too high or trigger will toggle
+        await setCrvTotalSupply(10n ** 18n);
+
+        // Call checkAndToggleTrigger to simulate someone using the protocol
+        await trigger.checkAndToggleTrigger();
+        expect(await trigger.isTriggered()).to.be.false; // sanity check
+        const newPricePerShare = await yCrvTricrypto.pricePerShare();
+        const newVirtualPrice = await crvTricrypto.get_virtual_price();
+
+        // Verify the new state
+        const currentPricePerShare = await trigger.lastPricePerShare();
+        expect(currentPricePerShare.toString()).to.equal(newPricePerShare.toString()); // bigint checks are flaky with chai
+        const currentVirtualPrice = await trigger.lastVirtualPrice();
+        expect(currentVirtualPrice.toString()).to.equal(newVirtualPrice.toString());
+      });
+
+      it('properly accounts for price per share tolerance', async () => {
+        // Modify the currently stored share price by a set tolerance. To increase share price by a tolerance, we
+        // decrease total supply by that amount
+        async function modifyLastPricePerShare(numerator: bigint, denominator: bigint) {
+          const lastPricePerShare = (await trigger.lastPricePerShare()).toBigInt();
+          const lastTotalSupply = (await yCrvTricrypto.totalSupply()).toBigInt();
+          const newTotalSupply = (lastTotalSupply * denominator) / numerator;
+          const newPricePerShare = (lastPricePerShare * numerator) / denominator;
+          await setYearnTotalSupply(newTotalSupply);
+          // Due to rounding error, values may sometimes differ by 1 wei, so validate with a tolerance +/2 wei
+          expect(await yCrvTricrypto.pricePerShare()).to.be.above(newPricePerShare - 2n);
+          expect(await yCrvTricrypto.pricePerShare()).to.be.below(newPricePerShare + 2n);
+        }
+
+        // Read the trigger's tolerance
+        const tolerance = (await trigger.vaultTol()).toBigInt();
+
+        // Increase share price to a larger value, should NOT be triggered (sanity check)
+        await modifyLastPricePerShare(101n, 100n); // 1% increase
+        await assertTriggerStatus(false);
+
+        // Decrease share price by an amount less than tolerance, should NOT be triggered
+        await modifyLastPricePerShare(99n, 100n); // 1% decrease
+        await assertTriggerStatus(false);
+
+        // Decrease share price by an amount exactly equal to tolerance, should NOT be triggered
+        await modifyLastPricePerShare(tolerance, 1000n);
+        await assertTriggerStatus(false);
+
+        // Decrease share price by an amount more than tolerance, should be triggered
+        await modifyLastPricePerShare(tolerance - 1n, 1000n);
+        await assertTriggerStatus(true);
+      });
+
+      it('properly accounts for virtual price tolerance', async () => {
+        // Modify the currently stored virtual price by a set tolerance
+        async function modifyLastVirtualPrice(numerator: bigint, denominator: bigint) {
+          const lastVirtualPrice = (await trigger.lastVirtualPrice()).toBigInt();
+          const lastTotalSupply = (await crvToken.totalSupply()).toBigInt();
+          const newTotalSupply = (lastTotalSupply * denominator) / numerator;
+          const newVirtualPrice = (lastVirtualPrice * numerator) / denominator;
+          await setCrvTotalSupply(newTotalSupply);
+          // Due to rounding error, values may sometimes differ by 1 wei, so validate with a tolerance +/2 wei
+          expect(await crvTricrypto.get_virtual_price()).to.be.above(newVirtualPrice - 2n);
+          expect(await crvTricrypto.get_virtual_price()).to.be.below(newVirtualPrice + 2n);
+        }
+
+        // Read the trigger's tolerance
+        const tolerance = (await trigger.virtualPriceTol()).toBigInt();
+
+        // Increase virtual price to a larger value, should NOT be triggered (sanity check)
+        await modifyLastVirtualPrice(101n, 100n); // 1% increase
+        await assertTriggerStatus(false);
+
+        // Decrease virtual price by an amount less than tolerance, should NOT be triggered
+        await modifyLastVirtualPrice(99n, 100n); // 1% decrease
+        await assertTriggerStatus(false);
+
+        // Decrease virtual price by an amount exactly equal to tolerance, should NOT be triggered
+        await modifyLastVirtualPrice(tolerance, 1000n);
+        await assertTriggerStatus(false);
+
+        // Decrease virtual price by an amount more than tolerance, should be triggered
+        await modifyLastVirtualPrice(tolerance - 1n, 1000n);
+        await assertTriggerStatus(true);
+      });
+
+      vault.curvePoolTokens.forEach((tokenSymbol) => {
+        it(`properly accounts for ${tokenSymbol.toUpperCase()} balance being drained`, async () => {
+          const tolerance = (await trigger.balanceTol()).toBigInt();
+
+          // Increase balance to a larger value, should NOT be triggered (sanity check)
+          await modifyCrvBalance(tokenSymbol, 101n, 100n); // 1% increase
+          await assertTriggerStatus(false);
+
+          // Decrease balance by an amount less than tolerance, should NOT be triggered
+          await modifyCrvBalance(tokenSymbol, 99n, 100n); // 1% decrease
+          await assertTriggerStatus(false);
+
+          // Decrease balance by an amount exactly equal to tolerance, should NOT be triggered
+          await modifyCrvBalance(tokenSymbol, tolerance, 1000n);
+          await assertTriggerStatus(false);
+
+          // Decrease balance by an amount more than tolerance, should be triggered
+          await modifyCrvBalance(tokenSymbol, tolerance - 1n, 1000n);
+          await assertTriggerStatus(true);
+        });
+      });
+    });
+  });
+});


### PR DESCRIPTION
Adds a new contract `YearnCrvTwoTokens`, which is a modified version of `YearnCrvTricrypto`. It's been modified so it can work as a trigger template for any Yearn vault that supplies to a Curve pool which has two underlying tokens and checks for 50% drops in any of the three conditions documented.

A corresponding new test file, `YearnCrvTwoTokens.test.ts` defines an array of `vaults`, and loops through the full test suite for each vault. This way, when we want to add deploy scripts for new Yearn Curve vaults, we can test the trigger for that vault very easily by adding another object to the `vaults` array.

The deploy script should be configured to deploy a Protection Market with the following parameters:
- WBTC as the underlying token
- Interest Rate Model TBD soon, currently using the same as the Tricrypto trigger
- All three checks use a 50% trigger threshold
- Yearn vault address: 0x23D3D0f1c697247d5e0a9efB37d8b0ED0C464f7f
- Curve p address: 0xC25099792E9349C7DD09759744ea681C7de2cb66
- tBTC token address: 0x8dAEBADE922dF735c38C80C7eBD708Af50815fAa
- crvRenWSBTC token address: 0x075b1bb99792c9E1041bA13afEf80C91a1e70fB3