### PR TITLE
Add Rari trigger

### DIFF
--- a/contracts/RariSharePrice.sol
+++ b/contracts/RariSharePrice.sol
@@ -1,0 +1,76 @@
+pragma solidity ^0.8.9;
+
+import "./interfaces/IERC20.sol";
+import "./interfaces/ITrigger.sol";
+
+interface IRariVault {
+  function getFundBalance() external returns (uint256);
+
+  function rariFundToken() external view returns (IERC20);
+}
+
+/**
+ * @notice Defines a trigger that is toggled if the share price of the Rari vault drops by
+ * over 50% between consecutive checks
+ */
+contract RariSharePrice is ITrigger {
+  /// @notice Rari vault this trigger is for
+  IRariVault public immutable market;
+
+  /// @notice Token address of that vault
+  IERC20 public immutable token;
+
+  /// @notice Last read share price
+  uint256 public lastPricePerShare;
+
+  /// @dev Scale used to define percentages. Percentages are defined as tolerance / scale
+  uint256 public constant scale = 1000;
+
+  /// @dev Tolerance for share price drop
+  uint256 public constant tolerance = 500; // 500 / 1000 = 50% tolerance
+
+  /**
+   * @param _market Address of the Rari vault this trigger should protect
+   * @dev For definitions of other constructor parameters, see ITrigger.sol
+   */
+  constructor(
+    string memory _name,
+    string memory _symbol,
+    string memory _description,
+    uint256[] memory _platformIds,
+    address _recipient,
+    address _market
+  ) ITrigger(_name, _symbol, _description, _platformIds, _recipient) {
+    // Set vault and save current share price
+    market = IRariVault(_market);
+    token = market.rariFundToken();
+    lastPricePerShare = getPricePerShare();
+  }
+
+  /**
+   * @dev Checks the Rari share price
+   */
+  function checkTriggerCondition() internal override returns (bool) {
+    // Read this blocks share price
+    uint256 _currentPricePerShare = getPricePerShare();
+
+    // Check if current share price is below current share price, accounting for tolerance
+    bool _status = _currentPricePerShare < ((lastPricePerShare * tolerance) / scale);
+
+    // Save the new share price
+    lastPricePerShare = _currentPricePerShare;
+
+    // Return status
+    return _status;
+  }
+
+  /**
+   * @dev Returns the effective price per share of the vault
+   */
+  function getPricePerShare() internal returns (uint256) {
+    // Both `getFundBalance() and `totalSupply()` return values with 18 decimals, so we scale the fund balance
+    // before division to increase the precision of this division. Without this scaling, the division will floor
+    // and often return 1, which is too coarse to be useful
+    return (market.getFundBalance() * 1e18) / token.totalSupply();
+  }
+}

--- a/hardhat.config.ts
+++ b/hardhat.config.ts
@@ -66,7 +66,7 @@ const config: HardhatUserConfig = {
     compilers: [
       {
         // Used for triggers
-        version: '0.8.6',
+        version: '0.8.9',
         settings: { metadata: { bytecodeHash: 'none' }, optimizer: { enabled: true, runs: 999999 } },
       },
       {

--- a/scripts/create-protection-market-rari.ts
+++ b/scripts/create-protection-market-rari.ts
@@ -1,0 +1,149 @@
+/**
+ * @notice Deploys the `RariSharePrice` trigger and creates a protection market
+ * @dev To deploy, you must define the RARI_VAULT environment variable and set it equal to one
+ * of the keys of the `vaults` variable, such as usdc or dai. Sample deploy commands are below:
+ *
+ *     RARI_VAULT=usdc yarn hardhat run scripts/create-protection-market-rari.ts
+ *     RARI_VAULT=dai yarn hardhat run scripts/create-protection-market-rari.ts --network mainnet
+ */
+
+import hre from 'hardhat';
+import '@nomiclabs/hardhat-ethers';
+import { Contract, ContractFactory, utils } from 'ethers';
+import chalk from 'chalk';
+import { getChainId, getContractAddress, getGasPrice, logSuccess, logFailure, findLog, waitForInput } from '../utils/utils'; // prettier-ignore
+import comptrollerAbi from '../abi/Comptroller.json';
+
+// Constants
+const { AddressZero } = hre.ethers.constants;
+const twoE16 = '20000000000000000'; // 2%
+const eightE17 = '800000000000000000'; // 80%
+const cozyMultisig = '0x1725d89c5cf12F1E9423Dc21FdadC81C491a868b';
+
+// STEP 0: ENVIRONMENT SETUP
+const provider = hre.ethers.provider;
+const signer = new hre.ethers.Wallet(process.env.PRIVATE_KEY as string, hre.ethers.provider);
+const chainId = getChainId(hre);
+
+// STEP 1: TRIGGER CONTRACT SETUP
+const platformIds = [10];
+// const recipient = signer.address;
+const recipient = '0xSetRecipientAddressHere'; // subsidy recipient
+
+// Mainnet parameters for various Rari vaults
+const vaults = {
+  usdc: {
+    name: 'Rari USDC Trigger',
+    symbol: 'rariUSDC-TRIG',
+    description : "Triggers when the Rari USDC vault share price decreases by more than 50% between consecutive checks.", // prettier-ignore
+    vaultAddress: '0xC6BF8C8A55f77686720E0a88e2Fd1fEEF58ddf4a',
+    irParams: [twoE16, '200000000000000000', '6150000000000000000', eightE17], // JumpRateModelV2 interest rate model constructor parameters
+  },
+  dai: {
+    name: 'Rari DAI Trigger',
+    symbol: 'rariDAI-TRIG',
+    description : "Triggers when the Rari DAI vault share price decreases by more than 50% between consecutive checks.", // prettier-ignore
+    vaultAddress: '0xB465BAF04C087Ce3ed1C266F96CA43f4847D9635', // TODO set this address
+    irParams: [twoE16, '170000000000000000', '5300000000000000000', eightE17], // JumpRateModelV2 interest rate model constructor parameters
+  },
+};
+
+// STEP 2: TRIGGER CONTRACT DEVELOPMENT
+// For this step, see the ITrigger.sol and MockTrigger.sol examples and the corresponding documentation
+
+// STEP 3: PROTECTION MARKET DEPLOYMENT
+async function main(): Promise<void> {
+  // Verify a valid vault was selected
+  const vault = process.env.RARI_VAULT as string;
+  if (!vault) {
+    const msg = "Please define the 'RARI_VAULT' environment variable. Keys of the `vaults` variable are valid values";
+    throw new Error(msg);
+  }
+  if (!Object.keys(vaults).includes(vault)) {
+    throw new Error(`Vault '${vault}'' is not a key in the \`vaults\` object`);
+  }
+  const { name, symbol, description, vaultAddress, irParams } = vaults[vault as keyof typeof vaults];
+
+  // Verify recipient address was set properly
+  if (!utils.isAddress(recipient)) throw new Error('\n\n**** Please set the recipient address on line 23 ****\n');
+
+  // Compile contracts to make sure we're using the latest version of the trigger contracts
+  await hre.run('compile');
+
+  // VERIFICATION
+  // Verify the user is ok with the provided inputs
+  console.log(chalk.bold.yellow('\nPLEASE VERIFY THE BELOW PARAMETERS\n'));
+  console.log(`  Deploying protection market for:   Rari ${vault.toUpperCase()} Vault`);
+  console.log(`  Deployer address:                  ${signer.address}`);
+  console.log(`  Deploying to network:              ${hre.network.name}`);
+
+  const response = await waitForInput('\nDo you want to continue with deployment? y/N\n');
+  if (response !== 'y') {
+    logFailure('\nUser chose to cancel deployment. Exiting script');
+    return;
+  }
+  logSuccess('Continuing with deployment...\n');
+
+  // DEPLOY INTEREST RATE MODEL
+  // Get instance of the Trigger ContractFactory with our signer attached
+  const irModelFactory: ContractFactory = await hre.ethers.getContractFactory('JumpRateModelV2', signer);
+
+  // Deploy the interest rate model
+  const irModelConstructorArgs = [...irParams, cozyMultisig];
+  const irModel: Contract = await irModelFactory.deploy(...irModelConstructorArgs);
+  await irModel.deployed();
+  logSuccess(`Interest rate model deployed to ${irModel.address}`);
+
+  // DEPLOY TRIGGER
+  // Get instance of the Trigger ContractFactory with our signer attached
+  const triggerFactory: ContractFactory = await hre.ethers.getContractFactory('RariSharePrice', signer);
+
+  // Deploy the trigger contract (last constructor parameter is specific to the mock trigger contract)
+  const triggerParams = [name, symbol, description, platformIds, recipient, vaultAddress];
+  const trigger: Contract = await triggerFactory.deploy(...triggerParams);
+  await trigger.deployed();
+  logSuccess(`RariSharePrice trigger deployed to ${trigger.address}`);
+
+  // VERIFY UNDERLYING
+  // Let's choose ETH as the underlying, so first we need to check if there's a ETH Money Market.
+  // We know that Money Markets have a trigger address of the zero address, so we use that to query the Comptroller
+  // for the Money Market address
+  const ethAddress = getContractAddress('ETH', chainId);
+  const comptrollerAddress = getContractAddress('Comptroller', chainId);
+  const comptroller = new Contract(comptrollerAddress, comptrollerAbi, signer); // connect signer for sending transactions
+  const cozyEthAddress = await comptroller.getCToken(ethAddress, AddressZero);
+
+  // If the returned address is the zero address, a money market does not exist and we cannot deploy a protection
+  // market with ETH as the underlying
+  if (cozyEthAddress === AddressZero) {
+    logFailure('No ETH Money Market exists. Exiting script');
+    return;
+  }
+  logSuccess(`Safe to continue: Found ETH Money Market at ${cozyEthAddress}`);
+
+  // DEPLOY PROTECTION MARKET
+  // If we're here, a ETH Money Market exists, so it's safe to create our new Protection Market
+  const overrides = { gasPrice: await getGasPrice() };
+  const tx = await comptroller['deployProtectionMarket(address,address,address)'](
+    ethAddress,
+    trigger.address,
+    irModel.address,
+    overrides
+  );
+  console.log(`Creating Protection Market in transaction ${tx.hash}`);
+
+  // This should emit a ProtectionMarketListed event on success, so let's check for that event. If not found, this
+  // method will throw and print the Failure error codes which can be looked up in ErrorReporter.sol
+  const { log, receipt } = await findLog(tx, comptroller, 'ProtectionMarketListed', provider);
+  logSuccess(`Success! Protection Market deployed to ${log?.args.cToken}`);
+
+  // Done! You have successfully deployed your protection market
+}
+
+// We recommend this pattern to be able to use async/await everywhere and properly handle errors.
+main()
+  .then(() => process.exit(0))
+  .catch((error: Error) => {
+    console.error(error);
+    process.exit(1);
+  });

--- a/test/RariPools.test.ts
+++ b/test/RariPools.test.ts
@@ -1,0 +1,190 @@
+// --- Imports ---
+import { artifacts, ethers, network, waffle } from 'hardhat';
+import { expect } from 'chai';
+import type { BigNumber, BigNumberish } from '@ethersproject/bignumber';
+import { SignerWithAddress } from '@nomiclabs/hardhat-ethers/dist/src/signer-with-address';
+import { MockCozyToken, IERC20, IRariVault, RariSharePrice } from '../typechain';
+
+// --- Constants and extracted methods ---
+const wad = 10n ** 18n;
+const { deployContract, loadFixture } = waffle;
+const { MaxUint256: MAX_UINT } = ethers.constants;
+const { hexZeroPad } = ethers.utils;
+const BN = (x: BigNumberish) => ethers.BigNumber.from(x);
+const to32ByteHex = (x: BigNumberish) => hexZeroPad(BN(x).toHexString(), 32);
+
+interface VaultInfo {
+  name: string;
+  market: string;
+}
+
+// Rari vaults
+const markets: VaultInfo[] = [
+  { name: 'Rari USDC Pool', market: '0xC6BF8C8A55f77686720E0a88e2Fd1fEEF58ddf4a' },
+  { name: 'Rari DAI Pool', market: '0xB465BAF04C087Ce3ed1C266F96CA43f4847D9635' },
+];
+
+// --- Tests ---
+markets.forEach((vault) => {
+  describe(`Vault: ${vault.name}`, function () {
+    // --- Data ---
+    let market: IRariVault;
+    let token: IERC20;
+    let deployer: SignerWithAddress;
+    let trigger: RariSharePrice;
+    let triggerParams: (string | number[])[] = []; // trigger params deployment parameters
+
+    // --- Functions modifying storage ---
+    /**
+     * @notice Change Rari vault's price per share by modifying total supply (since share price is a getter method that
+     * divides by total token supply)
+     * @param supply New total supply. To zero out share price, use MAX_UINT256, which simulates unlimited minting of
+     * shares, making price per share effectively 0
+     */
+    async function setVaultTotalSupply(supply: BigNumberish) {
+      const storageSlot = '0x35';
+      await network.provider.send('hardhat_setStorageAt', [token.address, storageSlot, to32ByteHex(supply)]);
+    }
+
+    // --- Test fixture ---
+    // Executes checkAndToggleTrigger and verifies the expected state
+    async function assertTriggerStatus(status: boolean) {
+      await trigger.checkAndToggleTrigger();
+      expect(await trigger.isTriggered()).to.equal(status);
+    }
+
+    // Gets the effective share price of the vault
+    async function getPricePerShare() {
+      const balance = <BigNumber>await market.callStatic.getFundBalance();
+      const supply = <BigNumber>await token.totalSupply();
+      return balance.mul(wad).div(supply); // need to scale balance before division since both balance and supply are on the scale of 1e18
+    }
+
+    /**
+     * @dev We change the values in storage slots of mainnet contracts in our tests, and normally these would persist
+     * between tests. But we don't want that, so we use this fixture to automatically snapshot the state after loading
+     * the fixture and revert to it before each test: https://github.com/EthWorks/Waffle/blob/3f46a6c8093cb9edb1a68c3ba15c4b4499ad595d/waffle-provider/src/fixtures.ts#L13-L35
+     */
+    async function setupFixture() {
+      // Get user accounts
+      const [deployer, recipient] = await ethers.getSigners();
+
+      // Get mainnet contract instances
+      const market = <IRariVault>await ethers.getContractAt('IRariVault', vault.market);
+      const token = <IERC20>await ethers.getContractAt('IERC20', await market.rariFundToken());
+
+      // Deploy trigger
+      const triggerParams = [
+        'Rari USDC Trigger', // name
+        'rariUSDC-TRIG', // symbol
+        'Triggers when the Rari USDC vault share price decreases by more than 50% between consecutive checks.', // description
+        [10], // platform ID
+        recipient.address, // subsidy recipient
+        vault.market, // mainnet address
+      ];
+
+      const triggerArtifact = await artifacts.readArtifact('RariSharePrice');
+      const trigger = <RariSharePrice>await deployContract(deployer, triggerArtifact, triggerParams);
+
+      return { deployer, market, token, trigger, triggerParams };
+    }
+
+    // --- Tests ---
+    beforeEach(async () => {
+      ({ deployer, market, token, trigger, triggerParams } = await loadFixture(setupFixture));
+    });
+
+    describe('Deployment', () => {
+      it('initializes properly', async () => {
+        expect(await trigger.name()).to.equal(triggerParams[0]);
+        expect(await trigger.symbol()).to.equal(triggerParams[1]);
+        expect(await trigger.description()).to.equal(triggerParams[2]);
+        const platformIds = (await trigger.getPlatformIds()).map((id) => id.toNumber());
+        expect(platformIds).to.deep.equal(triggerParams[3]); // use `.deep.equal` to compare array equality
+        expect(await trigger.recipient()).to.equal(triggerParams[4]);
+        expect(await trigger.market()).to.equal(triggerParams[5]);
+        expect(await trigger.tolerance()).to.equal('500');
+      });
+    });
+
+    describe('checkAndToggleTrigger', () => {
+      it('does nothing when called on a valid market', async () => {
+        expect(await trigger.isTriggered()).to.be.false;
+        await trigger.checkAndToggleTrigger();
+        expect(await trigger.isTriggered()).to.be.false;
+      });
+
+      it('toggles trigger when called on a broken market', async () => {
+        expect(await trigger.isTriggered()).to.be.false;
+
+        await setVaultTotalSupply(MAX_UINT);
+        expect(await trigger.isTriggered()).to.be.false; // trigger not updated yet, so still expect false
+
+        const tx = await trigger.checkAndToggleTrigger();
+        await expect(tx).to.emit(trigger, 'TriggerActivated');
+        expect(await trigger.isTriggered()).to.be.true;
+      });
+
+      it('returns a boolean with the value of isTriggered', async () => {
+        // Deploy our helper contract for testing, which has a state variable called isTriggered that stores the last
+        // value returned from trigger.checkAndToggleTrigger()
+        const mockCozyTokenArtifact = await artifacts.readArtifact('MockCozyToken');
+        const mockCozyToken = <MockCozyToken>await deployContract(deployer, mockCozyTokenArtifact, [trigger.address]);
+        expect(await mockCozyToken.isTriggered()).to.be.false;
+
+        // Break the vault
+        await setVaultTotalSupply(MAX_UINT);
+        await mockCozyToken.checkAndToggleTrigger();
+        expect(await mockCozyToken.isTriggered()).to.be.true;
+      });
+
+      it('properly updates the saved state', async () => {
+        // Update values
+        await setVaultTotalSupply(10n ** 18n); // don't set them too high or trigger will toggle
+
+        // Call checkAndToggleTrigger to simulate someone using the protocol
+        await trigger.checkAndToggleTrigger();
+        expect(await trigger.isTriggered()).to.be.false; // sanity check
+        const newPricePerShare = await getPricePerShare();
+
+        // Verify the new state
+        const currentPricePerShare = await trigger.lastPricePerShare();
+        expect(currentPricePerShare.toString()).to.equal(newPricePerShare.toString()); // bigint checks are flaky with chai
+      });
+
+      it('properly accounts for price per share tolerance', async () => {
+        // Modify the currently stored share price by a set tolerance. To increase share price by a tolerance, we
+        // decrease total supply by that amount
+        async function modifyLastPricePerShare(numerator: bigint, denominator: bigint) {
+          const lastPricePerShare = (await trigger.lastPricePerShare()).toBigInt();
+          const lastTotalSupply = (await token.totalSupply()).toBigInt();
+          const newTotalSupply = (lastTotalSupply * denominator) / numerator;
+          const newPricePerShare = (lastPricePerShare * numerator) / denominator;
+          await setVaultTotalSupply(newTotalSupply);
+          // Due to rounding error, values may sometimes differ by 1 wei, so validate with a tolerance +/2 wei
+          expect(await getPricePerShare()).to.be.above(newPricePerShare - 2n);
+          expect(await getPricePerShare()).to.be.below(newPricePerShare + 2n);
+        }
+
+        // Read the trigger's tolerance
+        const tolerance = (await trigger.tolerance()).toBigInt();
+
+        // Increase share price to a larger value, should NOT be triggered (sanity check)
+        await modifyLastPricePerShare(101n, 100n); // 1% increase
+        await assertTriggerStatus(false);
+
+        // Decrease share price by an amount less than tolerance, should NOT be triggered
+        await modifyLastPricePerShare(99n, 100n); // 1% decrease
+        await assertTriggerStatus(false);
+
+        // Decrease share price by an amount exactly equal to tolerance, should NOT be triggered
+        await modifyLastPricePerShare(tolerance, 1000n);
+        await assertTriggerStatus(false);
+
+        // Decrease share price by an amount more than tolerance, should be triggered
+        await modifyLastPricePerShare(tolerance - 1n, 1000n);
+        await assertTriggerStatus(true);
+      });
+    });
+  });
+});


### PR DESCRIPTION
Adds a trigger contract that can be used for any Rari vault, and configures the tests and deploy script to work with both the Rari USDC and Rari DAI vaults